### PR TITLE
Fix get_var_location

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,6 @@ cmake  ..                                    \
        -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX   \
        -DCMAKE_PREFIX_PATH:PATH=$PREFIX      \
        -DCMAKE_C_COMPILER=$CC                \
-       -DCMAKE_CXX_COMPILER=$CXX             \
        -DCMAKE_BUILD_TYPE=Release            \
        -DDCMAKE_INCLUDE_PATH=$PREFIX/include \
        -DCMAKE_LIBRARY_PATH=$PREFIX/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://github.com/csdms-contrib/hydrotrend/archive/v{{ version }}.tar.gz
   sha256: 0893d2669ec69f00a5e2d83b12dc35856ab12230e5deb5f22fd87e42f0f92f33
+  patches:
+    - var_at_node.patch  # get_var_location should return "node", not "grid"
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/var_at_node.patch
+++ b/recipe/var_at_node.patch
@@ -1,0 +1,13 @@
+diff --git a/bmi_hydrotrend.c b/bmi_hydrotrend.c
+index 4abdc19..e3e8a02 100644
+--- a/bmi_hydrotrend.c
++++ b/bmi_hydrotrend.c
+@@ -432,7 +432,7 @@ get_var_nbytes(void *self, const char *name, int *nbytes)
+ static int
+ get_var_location(void *self, const char *name, char *loc)
+ {
+-    strncpy(loc, "grid", BMI_MAX_VAR_NAME);
++    strncpy(loc, "node", BMI_MAX_VAR_NAME);
+     return BMI_SUCCESS;
+ }
+ 


### PR DESCRIPTION
This pull request adds a patch that fixes the `get_var_location` function for the HydroTrend BMI. Instead of setting the var location to "grid", set it to "node". This will be fixed in the next HydroTrend release but, until then, just use this patch. Also, since we don't compile with the c++ compiler, remove `CMAKE_CXX_COMPILER`.