### PR TITLE
Add patch for get_var_itemsize.

### DIFF
--- a/recipe/get_var_itemsize.patch
+++ b/recipe/get_var_itemsize.patch
@@ -1,0 +1,12 @@
+diff --git a/bmi_hydrotrend.c b/bmi_hydrotrend.c
+index 4abdc19..c8b2c8d 100644
+--- a/bmi_hydrotrend.c
++++ b/bmi_hydrotrend.c
+@@ -584,6 +584,7 @@ register_bmi_hydrotrend(BMI_Model *model)
+     model->get_var_type = get_var_type;
+     model->get_var_units = get_var_units;
+     model->get_var_nbytes = get_var_nbytes;
++    model->get_var_itemsize = get_var_itemsize;
+     model->get_var_location = get_var_location;
+     model->get_current_time = get_current_time;
+     model->get_start_time = get_start_time;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 0893d2669ec69f00a5e2d83b12dc35856ab12230e5deb5f22fd87e42f0f92f33
   patches:
     - var_at_node.patch  # get_var_location should return "node", not "grid"
+    - get_var_itemsize.patch  # fix get_var_itemsize not set
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
This pull request add a patch to hydrotrend that fixes a problem where `get_var_itemsize` was not being set and so would result in a segmentation fault if it was called. As with #3, this will be fixed in the next Hydrotrend release but, until then, use this patch.